### PR TITLE
relative_to() with walk_up capapility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - `Path.stat()` returns a `StatResult` object to get file or directory information containing
   - `TimeInt` objects for `atime`, `ctime`, `mtime` and `birthtime`
   - `ByteInt` object for `size`
+- `Path.relative_to()` to get relative path from a file or directory, `walk_up` to walk up the directory tree.
 
 ## Installation
 

--- a/docs/README.md.jinja2
+++ b/docs/README.md.jinja2
@@ -27,6 +27,7 @@
 - `Path.stat()` returns a `StatResult` object to get file or directory information containing
   - `TimeInt` objects for `atime`, `ctime`, `mtime` and `birthtime`
   - `ByteInt` object for `size`
+- `Path.relative_to()` to get relative path from a file or directory, `walk_up` to walk up the directory tree.
 
 ## Installation
 

--- a/pathlibutil/path.py
+++ b/pathlibutil/path.py
@@ -401,14 +401,14 @@ class Path(BasePath):
         Return a new `Path` with changed suffix or remove it when its an empty
         string.
 
+        Multiple suffixes can be changed at once by passing a list of suffixes.
+        With a empty list all suffixes will be removed.
+
         >>> Path('test.a.b').with_suffix('.c')
         Path('test.a.c')
 
         >>> Path('test.a.b').with_suffix('')
         Path('test.a')
-
-        Multiple suffixes can be changed at once by passing a list of suffixes.
-        With a empty list all suffixes will be removed.
 
         >>> Path('test.a.b').with_suffix(['.c', '.d'])
         Path('test.c.d')

--- a/pathlibutil/path.py
+++ b/pathlibutil/path.py
@@ -432,7 +432,7 @@ class Path(BasePath):
             end = -1 * len(self.suffixes) or None
             name = self.name.split(".")[0:end]
             stem = self.parent.joinpath("".join(name))
-            return super(Path, stem).with_suffix(suffix)
+            return super(self.__class__, stem).with_suffix(suffix)
 
 
 class Register7zFormat(Path, archive="7z"):

--- a/pathlibutil/path.py
+++ b/pathlibutil/path.py
@@ -434,6 +434,47 @@ class Path(BasePath):
             stem = self.parent.joinpath("".join(name))
             return super(self.__class__, stem).with_suffix(suffix)
 
+    def relative_to(
+        self, *other: Union[str, _Path], walk_up: Union[bool, int] = False
+    ) -> _Path:
+        """
+        Return the relative path to another path identified by the passed
+        arguments.  If the operation is not possible (because this is not
+        related to the other path), raise `ValueError`.
+
+        The `walk_up` parameter controls whether `..` may be used to resolve
+        the path.
+
+        If `walk_up` is a integer it specifies the maximum number of `..` to resolve, if
+        max is reached a `ValueError` is raised.
+
+        >>> Path('a/b/c/d').relative_to('a/b')
+        Path('c/d')
+
+        >>> Path('a/b/c/d').relative_to('a/b/e/f/g', walk_up=True)
+        Path('../../../c/d')
+
+        >>> Path('a/b/c/d').relative_to('a/b/e/f/g', walk_up=2)
+        ValueError: '../../../c/d' is outside of the relative deepth of '2'
+        """
+        if not walk_up:
+            return super().relative_to(*other)
+
+        try:
+            relative = super().relative_to(*other, walk_up=walk_up)
+        except TypeError:
+            relative = self.__class__(os.path.relpath(self, Path(*other)))
+
+        if type(walk_up) is not int:
+            return relative
+
+        if relative.parts.count("..") > walk_up:
+            raise ValueError(
+                f"'{relative}' is outside of the relative deepth of '{walk_up}'"
+            )
+
+        return relative
+
 
 class Register7zFormat(Path, archive="7z"):
     """

--- a/pathlibutil/types.py
+++ b/pathlibutil/types.py
@@ -2,7 +2,7 @@ import functools
 import os
 import re
 from datetime import datetime, tzinfo
-from typing import Set, Tuple, TypeVar
+from typing import Set, Tuple, TypeVar, Iterable
 
 _ByteInt = TypeVar("_ByteInt", bound="ByteInt")
 _stat_result = TypeVar("_stat_result", bound="os.stat_result")
@@ -332,3 +332,22 @@ class StatResult:
         Return representation of `os.stat_result` object.
         """
         return repr(self._obj)
+
+    def __dir__(self) -> Iterable[str]:
+        """
+        Return a list of attributes of `os.stat_result` object.
+        """
+        return dir(self._obj)
+
+    def __len__(self) -> int:
+        """
+        Return length of `os.stat_result` object.
+        """
+        return len(self._obj)
+
+    @property
+    def stat_result(self) -> os.stat_result:
+        """
+        Return the wrapped `os.stat_result` object.
+        """
+        return self._obj

--- a/tests/test_relative.py
+++ b/tests/test_relative.py
@@ -1,0 +1,63 @@
+import pytest
+
+from pathlibutil import Path
+
+
+@pytest.fixture(
+    params=[
+        ("a/b/c", "a/c/d", "../../b/c"),
+        ("a/b/c/d", "a/b/e/f", "../../c/d"),
+        ("a/b/c", "d/e/f", "../../../a/b/c"),
+    ]
+)
+def relative_up(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        ("a/b/c", "a/b/c", ""),
+        ("a/b/c", "a/b/c", "."),
+        ("a/b/c", "a/b", "c"),
+        ("a/b/c", "a", "b/c"),
+        ("a/b/c", ".", "a/b/c"),
+        ("a/b/c", "", "a/b/c"),
+    ]
+)
+def relative_down(request):
+    return request.param
+
+
+def test_relative_to(relative_down):
+    start, path, result = relative_down
+
+    p = Path(start).relative_to(path)
+    assert p == Path(result)
+
+
+def test_relative_up_bool(relative_up):
+    start, path, result = relative_up
+
+    p = Path(start).relative_to(path, walk_up=True)
+    assert p == Path(result)
+
+
+def test_relative_up_int(relative_up):
+    start, path, result = relative_up
+
+    p = Path(start).relative_to(path, walk_up=3)
+    assert p == Path(result)
+
+
+def test_relative_raises(relative_up):
+    start, path, _ = relative_up
+
+    with pytest.raises(ValueError):
+        Path(start).relative_to(path)
+
+
+def test_relative_raises_up_int(relative_up):
+    start, path, _ = relative_up
+
+    with pytest.raises(ValueError):
+        Path(start).relative_to(path, walk_up=1)

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -45,7 +45,7 @@ def test_copy_raises(file: Path, tmp_path: pathlib.Path):
         Path("notexists").copy(tmp_path)
 
 
-@pytest.mark.xfail(reason="dst directory will be created when copy a file")
+@pytest.mark.xfail(reason="dst directory will be created when copy a file", strict=True)
 def test_copy_mkdir(file: Path, tmp_path: pathlib.Path):
     with pytest.raises(FileNotFoundError):
         file.copy(tmp_path / "not-exists")

--- a/tests/test_stat.py
+++ b/tests/test_stat.py
@@ -40,22 +40,13 @@ def test_stat_attr_result(arg):
         pytest.skip(f"{arg} is callable and not tested")
 
 
-@pytest.mark.parametrize("arg", ["st_atime", "st_mtime", "st_ctime"])
-def test_stat_time(arg):
+@pytest.mark.parametrize("time", [t for t in dir(os.stat_result) if t.endswith("time")])
+def test_stat_time(time):
     """check if the results for times are TimeInt objects"""
 
     s = Path(__file__).stat()
 
-    assert type(getattr(s, arg)) == TimeInt
-
-
-@pytest.mark.xfail(reason="Attribute not always available")
-def test_stat_birthtime():
-    """check if the result for st_birthtime is a TimeInt object"""
-
-    s = Path(__file__).stat()
-
-    assert type(s.st_birthtime) == TimeInt
+    assert type(getattr(s, time)) == TimeInt
 
 
 def test_stat_size():
@@ -66,7 +57,7 @@ def test_stat_size():
     assert type(s.st_size) == ByteInt
 
 
-@pytest.mark.parametrize("cast", [str, repr])
+@pytest.mark.parametrize("cast", [str, repr, dir, len])
 def test_stat_functions(cast):
     s = Path(__file__).stat()
     o = os.stat(__file__)

--- a/tests/test_stat.py
+++ b/tests/test_stat.py
@@ -63,3 +63,11 @@ def test_stat_functions(cast):
     o = os.stat(__file__)
 
     assert cast(s) == cast(o)
+
+
+def test_stat_result():
+    """check if the result for st_result is a StatResult object"""
+
+    s = Path(__file__).stat()
+
+    assert type(s.stat_result) == os.stat_result


### PR DESCRIPTION
- support `walk_up` feature introduced in py312 also in py3.8+
- enhanced walk_up to `int` to limit the `..`